### PR TITLE
Typo in recent_posts.ejs 

### DIFF
--- a/layout/_widget/recent_posts.ejs
+++ b/layout/_widget/recent_posts.ejs
@@ -5,7 +5,7 @@
       <% site.posts.sort( 'date', -1).limit(5).each(function(post){ %>
         <li>
           <a href="<%- url_for(post.path) %>">
-            <%=p ost.title || '(no title)' %>
+            <%= post.title || '(no title)' %>
           </a>
         </li>
         <% }); %>


### PR DESCRIPTION
There was a typo (an additional space) in line 8 of the recent_posts.ejs
